### PR TITLE
Fix proposal tasks

### DIFF
--- a/src/tasks/proposals.ts
+++ b/src/tasks/proposals.ts
@@ -37,8 +37,7 @@ task("addProposal", "Adds a proposal question")
         .addParam("proposalFile", "File with proposal information json", undefined, types.inputFile)
         .setAction(async (taskArgs, hardhatRuntime) => {
             const ethers = hardhatRuntime.ethers;
-            const Module = await ethers.getContractFactory("RealityModule");
-            const module = await Module.attach(taskArgs.module);
+            const module = await ethers.getContractAt("RealityModule", taskArgs.module);
 
             const proposal = await getProposalDetails(module, taskArgs.proposalFile);
 
@@ -51,8 +50,7 @@ task("showProposal", "Shows proposal question details")
         .addParam("proposalFile", "File with proposal information json", undefined, types.inputFile)
         .setAction(async (taskArgs, hardhatRuntime) => {
             const ethers = hardhatRuntime.ethers;
-            const Module = await ethers.getContractFactory("RealityModule");
-            const module = await Module.attach(taskArgs.module);
+            const module = await ethers.getContractAt("RealityModule", taskArgs.module);
 
             const proposal = await getProposalDetails(module, taskArgs.proposalFile);
 
@@ -71,8 +69,7 @@ task("executeProposal", "Executes a proposal")
         .addParam("proposalFile", "File with proposal information json", undefined, types.inputFile)
         .setAction(async (taskArgs, hardhatRuntime) => {
             const ethers = hardhatRuntime.ethers;
-            const Module = await ethers.getContractFactory("RealityModule");
-            const module = await Module.attach(taskArgs.module);
+            const module = await ethers.getContractAt("RealityModule", taskArgs.module);
 
             const proposal = await getProposalDetails(module, taskArgs.proposalFile);
 


### PR DESCRIPTION
The `RealityModule` is abstract and therefore cannot be instantiated with a contract factory. Therefore `getContractAt` should be used.