### PR TITLE
Deterministic setup with template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ env/
 .history
 coverage*
 deployments
+.vscode/*

--- a/contracts/DeterministicDeploymentHelper.sol
+++ b/contracts/DeterministicDeploymentHelper.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import "@gnosis.pm/zodiac/contracts/core/Module.sol";
+import "./interfaces/RealitioV3.sol";
+import "./RealityModule.sol";
+
+contract DeterministicDeploymentHelper {
+  function createTemplateAndChangeOwner(
+    string calldata templateContent,
+    address realityOracle,
+    address realityModuleInstance,
+    address newOwner
+  ) public {
+    uint256 templateId = RealitioV3(realityOracle).createTemplate(
+      templateContent
+    );
+    RealityModule(realityModuleInstance).setTemplate(templateId);
+    RealityModule(realityModuleInstance).transferOwnership(newOwner);
+  }
+}

--- a/contracts/DeterministicDeploymentHelper.sol
+++ b/contracts/DeterministicDeploymentHelper.sol
@@ -4,18 +4,17 @@ pragma solidity >=0.8.0;
 import "@gnosis.pm/zodiac/contracts/core/Module.sol";
 import "./interfaces/RealitioV3.sol";
 import "./RealityModule.sol";
+import "@gnosis.pm/zodiac/contracts/factory/ModuleProxyFactory.sol";
 
 contract DeterministicDeploymentHelper {
   function createTemplateAndChangeOwner(
     string calldata templateContent,
-    address realityOracle,
-    address realityModuleInstance,
+    RealitioV3 realityOracle,
+    RealityModule realityModuleInstance,
     address newOwner
   ) public {
-    uint256 templateId = RealitioV3(realityOracle).createTemplate(
-      templateContent
-    );
-    RealityModule(realityModuleInstance).setTemplate(templateId);
-    RealityModule(realityModuleInstance).transferOwnership(newOwner);
+    uint256 templateId = realityOracle.createTemplate(templateContent);
+    realityModuleInstance.setTemplate(templateId);
+    realityModuleInstance.transferOwnership(newOwner);
   }
 }

--- a/contracts/DeterministicDeploymentHelper.sol
+++ b/contracts/DeterministicDeploymentHelper.sol
@@ -6,37 +6,66 @@ import "./interfaces/RealitioV3.sol";
 import "./RealityModule.sol";
 import "@gnosis.pm/zodiac/contracts/factory/ModuleProxyFactory.sol";
 
+/**
+ * @title Deterministic Deployment Helper
+ * @notice This contract contains helper functions that can be used to deploy the RealityModule to a deterministic address even though the template is new
+ * @dev This is needed because if a new template is added in the same transaction, the template ID is unknown until the template is created.
+ * This is unnecessary if the template ID is already known (the template has been created in an earlier transaction).
+ * This functionality is helpful if the template will be created and the RealityModule deployed in the same transaction.
+ */
 contract DeterministicDeploymentHelper {
   event ModuleProxyCreation(address indexed proxy, address indexed masterCopy);
+  event ModuleProxyConfigured(uint256 templateId);
 
+  /// @notice It creates the template on the oracle, then sets the template ID on the module and transfers ownership of the module to the specified owner
+  /// @dev
+  /// @param moduleInstance The module instance
+  /// @param realityOracle The address of the oracle instance to use
+  /// @param templateContent The Reality.eth template
+  /// @param newOwner The address that should be set as the Module owner
+  /// @return templateId The templates ID at the reality oracle
   function createTemplateAndChangeOwner(
-    string calldata templateContent,
+    RealityModule moduleInstance,
     RealitioV3 realityOracle,
-    RealityModule realityModuleInstance,
+    string calldata templateContent,
     address newOwner
-  ) public {
-    uint256 templateId = realityOracle.createTemplate(templateContent);
-    realityModuleInstance.setTemplate(templateId);
-    realityModuleInstance.transferOwnership(newOwner);
+  ) public returns (uint256 templateId) {
+    templateId = realityOracle.createTemplate(templateContent);
+    moduleInstance.setTemplate(templateId);
+    moduleInstance.transferOwnership(newOwner);
+    emit ModuleProxyConfigured(templateId);
   }
 
+  /// @notice Deploys the Reality Module to a deterministic address, then creates the template and sets ownership to the specified owner
+  /// @dev In the init parameters the owner must be set to the address of this contract and the templateId should be set to 0
+  /// @param factory The Module Proxy Factory used for deploying modules
+  /// @param masterCopy The modules implementation logic, used for the Proxy (Module instance)
+  /// @param initParams The initialization parameters passed to the factory, used for calling the setup function with the required parameters.
+  /// @param saltNonce The salt used in the creation of the proxy
+  /// @param realityOracle The address of the Reality.eth oracle instance to use
+  /// @param templateContent The Reality.eth template
+  /// @param finalModuleOwner The address that should be set as the Module owner
+  /// @return realityModuleProxy , rounded up for partial years
   function deployWithTemplate(
     ModuleProxyFactory factory,
     address masterCopy,
     bytes memory initParams, // function selector and parameters for the initializer
     uint256 saltNonce,
-    string calldata templateContent,
     RealitioV3 realityOracle,
-    address moduleModifierOwner
+    string calldata templateContent,
+    address finalModuleOwner
   ) public returns (address realityModuleProxy) {
     realityModuleProxy = factory.deployModule(
       masterCopy,
       initParams,
       saltNonce
     );
-    uint256 templateId = realityOracle.createTemplate(templateContent);
-    RealityModule(realityModuleProxy).setTemplate(templateId);
-    RealityModule(realityModuleProxy).transferOwnership(moduleModifierOwner);
+    createTemplateAndChangeOwner(
+      RealityModule(realityModuleProxy),
+      realityOracle,
+      templateContent,
+      finalModuleOwner
+    );
     emit ModuleProxyCreation(realityModuleProxy, masterCopy);
   }
 }

--- a/contracts/DeterministicDeploymentHelper.sol
+++ b/contracts/DeterministicDeploymentHelper.sol
@@ -93,7 +93,7 @@ contract DeterministicDeploymentHelper {
     address masterCopy,
     uint256 saltNonce,
     ModuleSetupParams calldata setupParams
-  ) public returns (address realityModuleProxy) {
+  ) external returns (address realityModuleProxy) {
     bytes memory initParams = abi.encodeWithSelector(
       RealityModule(masterCopy).setUp.selector,
       abi.encode(

--- a/contracts/DeterministicDeploymentHelper.sol
+++ b/contracts/DeterministicDeploymentHelper.sol
@@ -15,7 +15,8 @@ import "@gnosis.pm/zodiac/contracts/factory/ModuleProxyFactory.sol";
  */
 contract DeterministicDeploymentHelper {
   event ModuleProxyCreation(address indexed proxy, address indexed masterCopy);
-  event ModuleProxyConfigured(uint256 templateId);
+  event ModuleProxyUpdateTemplate(uint256 templateId);
+  event ModuleProxyUpdateOwner(address newOwner);
 
   /// @notice It creates the template on the oracle, then sets the template ID on the module.
   /// @dev This function is meant to be called via a delegate call from the owner of the module (most often the Safe).
@@ -30,7 +31,7 @@ contract DeterministicDeploymentHelper {
   ) public returns (uint256 templateId) {
     templateId = realityOracle.createTemplate(templateContent);
     moduleInstance.setTemplate(templateId);
-    emit ModuleProxyConfigured(templateId);
+    emit ModuleProxyUpdateTemplate(templateId);
   }
 
   /// @notice It creates the template on the oracle, then sets the template ID on the module and transfers ownership of the module to the specified owner
@@ -46,10 +47,9 @@ contract DeterministicDeploymentHelper {
     string calldata templateContent,
     address newOwner
   ) public returns (uint256 templateId) {
-    templateId = realityOracle.createTemplate(templateContent);
-    moduleInstance.setTemplate(templateId);
+    templateId = createTemplate(moduleInstance, realityOracle, templateContent);
     moduleInstance.transferOwnership(newOwner);
-    emit ModuleProxyConfigured(templateId);
+    emit ModuleProxyUpdateOwner(newOwner);
   }
 
   /// @notice Deploys the Reality Module to a deterministic address, then creates the template and sets ownership to the specified owner

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,6 +5,7 @@ import "hardhat-deploy";
 import dotenv from "dotenv";
 import type { HttpNetworkUserConfig } from "hardhat/types";
 import yargs from "yargs";
+import "./src/tasks/deployDeterministicDeploymentHelper";
 
 const argv = yargs
   .option("network", {
@@ -35,7 +36,7 @@ if (PK) {
 
 if (["rinkeby", "mainnet"].includes(argv.network) && INFURA_KEY === undefined) {
   throw new Error(
-    `Could not find Infura key in env, unable to connect to network ${argv.network}`,
+    `Could not find Infura key in env, unable to connect to network ${argv.network}`
   );
 }
 
@@ -47,10 +48,7 @@ export default {
     sources: "contracts",
   },
   solidity: {
-    compilers: [
-      { version: "0.8.0" },
-      { version: "0.6.12" },
-    ]
+    compilers: [{ version: "0.8.0" }, { version: "0.6.12" }],
   },
   networks: {
     mainnet: {
@@ -67,12 +65,12 @@ export default {
     },
     matic: {
       ...sharedNetworkConfig,
-      url: "https://rpc-mainnet.maticvigil.com"
+      url: "https://rpc-mainnet.maticvigil.com",
     },
     bsc: {
       ...sharedNetworkConfig,
-      url: "https://bsc-dataseed.binance.org"
-    }
+      url: "https://bsc-dataseed.binance.org",
+    },
   },
   namedAccounts: {
     deployer: 0,

--- a/src/tasks/deployDeterministicDeploymentHelper.ts
+++ b/src/tasks/deployDeterministicDeploymentHelper.ts
@@ -1,0 +1,107 @@
+import "hardhat-deploy";
+import "@nomiclabs/hardhat-ethers";
+import { task } from "hardhat/config";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+const singletonFactoryAbi = [
+  "function deploy(bytes memory _initCode, bytes32 _salt) public returns (address payable createdContract)",
+];
+const singletonFactoryAddress = "0xce0042b868300000d44a59004da54a005ffdcf9f";
+const factorySalt =
+  "0xb0519c4c4b7945db302f69180b86f1a668153a476802c1c445fcb691ef23ef16";
+const AddressZero = "0x0000000000000000000000000000000000000000";
+
+const deployFactory = async (_: null, hardhat: HardhatRuntimeEnvironment) => {
+  const [deployer] = await hardhat.ethers.getSigners();
+  console.log("Deployer address:      ", deployer.address);
+
+  const singletonDeployer = "0xBb6e024b9cFFACB947A71991E386681B1Cd1477D";
+  const singletonFactory = new hardhat.ethers.Contract(
+    singletonFactoryAddress,
+    singletonFactoryAbi,
+    deployer
+  );
+
+  if (
+    (await hardhat.ethers.provider.getCode(singletonFactory.address)) === "0x"
+  ) {
+    // if the singelton factory is not deployed on the network
+    // fund the singleton factory deployer account
+    await deployer.sendTransaction({
+      to: singletonDeployer,
+      value: hardhat.ethers.utils.parseEther("0.0247"),
+    });
+
+    // deploy the singleton factory
+    await (
+      await hardhat.ethers.provider.sendTransaction(
+        "0xf9016c8085174876e8008303c4d88080b90154608060405234801561001057600080fd5b50610134806100206000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634af63f0214602d575b600080fd5b60cf60048036036040811015604157600080fd5b810190602081018135640100000000811115605b57600080fd5b820183602082011115606c57600080fd5b80359060200191846001830284011164010000000083111715608d57600080fd5b91908080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929550509135925060eb915050565b604080516001600160a01b039092168252519081900360200190f35b6000818351602085016000f5939250505056fea26469706673582212206b44f8a82cb6b156bfcc3dc6aadd6df4eefd204bc928a4397fd15dacf6d5320564736f6c634300060200331b83247000822470"
+      )
+    ).wait();
+
+    if (
+      (await hardhat.ethers.provider.getCode(singletonFactory.address)) == "0x"
+    ) {
+      console.log(
+        "Singleton factory could not be deployed to correct address, deployment haulted."
+      );
+      return;
+    }
+  }
+  console.log("Singleton Factory:     ", singletonFactory.address);
+
+  const Factory = await hardhat.ethers.getContractFactory(
+    "DeterministicDeploymentHelper"
+  );
+  // const singletonFactory = new hardhat.ethers.Contract(singletonFactoryAddress, singletonFactoryAbi)
+
+  const targetAddress = await singletonFactory.callStatic.deploy(
+    Factory.bytecode,
+    factorySalt
+  );
+  if (targetAddress == AddressZero) {
+    console.log(
+      "DeterministicDeploymentHelper already deployed to target address on this network."
+    );
+    return;
+  } else {
+    console.log("Target Address:", targetAddress);
+  }
+
+  const transactionResponse = await singletonFactory.deploy(
+    Factory.bytecode,
+    factorySalt,
+    { gasLimit: 2000000 }
+  );
+
+  const result = await transactionResponse.wait();
+  console.log("Deploy transaction:    ", result.transactionHash);
+
+  const factory = await hardhat.ethers.getContractAt(
+    "DeterministicDeploymentHelper",
+    targetAddress
+  );
+
+  const factoryArtifact = await hardhat.artifacts.readArtifact(
+    "DeterministicDeploymentHelper"
+  );
+
+  if (
+    (await hardhat.ethers.provider.getCode(factory.address)) !=
+    factoryArtifact.deployedBytecode
+  ) {
+    console.log("Deployment unsuccessful: deployed bytecode does not match.");
+    return;
+  } else {
+    console.log(
+      "Successfully deployed DeterministicDeploymentHelper to target address! 🎉"
+    );
+  }
+};
+
+task(
+  "deployment-helper-singleton-deployment",
+  "Deploy DeterministicDeploymentHelper through singleton factory"
+).setAction(deployFactory);
+
+module.exports = {};

--- a/test/DeterministicDeploymentHelper.spec.ts
+++ b/test/DeterministicDeploymentHelper.spec.ts
@@ -15,6 +15,7 @@ const DEFAULT_TEMPLATE = {
   type: "bool",
   category: "DAO proposal",
 };
+let proxyAddress0: string;
 let proxyAddress1: string;
 let proxyAddress2: string;
 let proxyAddress3: string;
@@ -109,7 +110,7 @@ describe("Module can be deployed and configured via the DeterministicDeploymentH
     } = receipt.events.find(
       ({ event }: { event: string }) => event === "ModuleProxyCreation"
     );
-    proxyAddress1 = newProxyAddress;
+    proxyAddress0 = newProxyAddress;
 
     const newProxy = await hre.ethers.getContractAt(
       "RealityModuleETH",
@@ -350,7 +351,8 @@ describe("Module can be deployed and configured via the DeterministicDeploymentH
   });
 
   it("no matter what deployment function is used, the module proxy should end up at the same address", async () => {
-    expect(proxyAddress1).to.equal(proxyAddress2);
-    expect(proxyAddress1).to.equal(proxyAddress3);
+    expect(proxyAddress0).to.equal(proxyAddress1);
+    expect(proxyAddress0).to.equal(proxyAddress2);
+    expect(proxyAddress0).to.equal(proxyAddress3);
   });
 });

--- a/test/DeterministicDeploymentHelper.spec.ts
+++ b/test/DeterministicDeploymentHelper.spec.ts
@@ -1,0 +1,136 @@
+import { expect } from "chai";
+import hre, { deployments, ethers } from "hardhat";
+import "@nomiclabs/hardhat-ethers";
+import { AbiCoder } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+
+const FIRST_ADDRESS = "0x0000000000000000000000000000000000000001";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const saltNonce = "0xfa";
+const defaultTemplate = {
+  title:
+    "Did the Snapshot proposal with the id %s pass the execution of the array of Module transactions with the hash 0x%s? The hash is the keccak of the concatenation of the individual EIP-712 hashes of the Module transactions. If this question was asked before the Snapshot proposal was resolved it should ALWAYS be resolved to INVALID!",
+  lang: "en",
+  type: "bool",
+  category: "DAO proposal",
+};
+
+describe("Module can be deployed and configured via the DeterministicDeploymentHelper", () => {
+  const timeout = 60;
+  const cooldown = 60;
+  const expiration = 120;
+  const bond = BigNumber.from(10000);
+  const templateId = BigNumber.from(0);
+
+  const paramsTypes = [
+    "address",
+    "address",
+    "address",
+    "address",
+    "uint32",
+    "uint32",
+    "uint32",
+    "uint256",
+    "uint256",
+    "address",
+  ];
+
+  const baseSetup = deployments.createFixture(async () => {
+    await deployments.fixture();
+    const Factory = await hre.ethers.getContractFactory("ModuleProxyFactory");
+    const RealityModuleETH = await hre.ethers.getContractFactory(
+      "RealityModuleETH"
+    );
+    const factory = await Factory.deploy();
+
+    const masterCopy = await RealityModuleETH.deploy(
+      FIRST_ADDRESS,
+      FIRST_ADDRESS,
+      FIRST_ADDRESS,
+      ZERO_ADDRESS,
+      1,
+      0,
+      60,
+      0,
+      0,
+      ZERO_ADDRESS
+    );
+
+    const Mock = await hre.ethers.getContractFactory("MockContract");
+    const mock = await Mock.deploy();
+    const oracle = await hre.ethers.getContractAt(
+      "RealitioV3ERC20",
+      mock.address
+    );
+
+    return { factory, masterCopy, mock, oracle };
+  });
+
+  it("can be deterministically set up and configured with a custom template", async () => {
+    const { factory, masterCopy, mock, oracle } = await baseSetup();
+    const [safe] = await ethers.getSigners();
+
+    const DeterministicDeploymentHelper = await hre.ethers.getContractFactory(
+      "DeterministicDeploymentHelper"
+    );
+
+    const deploymentHelper = await DeterministicDeploymentHelper.deploy();
+
+    const paramsValues = [
+      deploymentHelper.address, // set the deterministic deployment helper to be the owner
+      safe.address,
+      safe.address,
+      oracle.address,
+      timeout,
+      cooldown,
+      expiration,
+      bond,
+      templateId,
+      oracle.address,
+    ];
+    const encodedParams = [new AbiCoder().encode(paramsTypes, paramsValues)];
+    const initParams = masterCopy.interface.encodeFunctionData(
+      "setUp",
+      encodedParams
+    );
+    const receipt = await factory
+      .deployModule(masterCopy.address, initParams, saltNonce)
+      .then((tx: any) => tx.wait());
+
+    // retrieve new address from event
+    const {
+      args: [newProxyAddress],
+    } = receipt.events.find(
+      ({ event }: { event: string }) => event === "ModuleProxyCreation"
+    );
+
+    const newProxyStep1 = await hre.ethers.getContractAt(
+      "RealityModuleETH",
+      newProxyAddress
+    );
+    expect(await newProxyStep1.template()).to.be.eq(BigNumber.from(0));
+    expect(await newProxyStep1.owner()).to.be.eq(deploymentHelper.address);
+
+    await mock.givenMethodReturnUint(
+      oracle.interface.getSighash("createTemplate"),
+      5
+    );
+
+    await deploymentHelper
+      .createTemplateAndChangeOwner(
+        JSON.stringify(defaultTemplate),
+        oracle.address,
+        newProxyAddress,
+        safe.address
+      )
+      .then((tx: any) => tx.wait());
+
+    const newProxyStep2 = await hre.ethers.getContractAt(
+      "RealityModuleETH",
+      newProxyAddress
+    );
+
+    expect(await newProxyStep2.template()).to.be.eq(BigNumber.from(5));
+    expect(await newProxyStep2.owner()).to.be.eq(safe.address);
+  });
+});

--- a/test/DeterministicDeploymentHelper.spec.ts
+++ b/test/DeterministicDeploymentHelper.spec.ts
@@ -118,9 +118,9 @@ describe("Module can be deployed and configured via the DeterministicDeploymentH
 
     await deploymentHelper
       .createTemplateAndChangeOwner(
-        JSON.stringify(defaultTemplate),
-        oracle.address,
         newProxyAddress,
+        oracle.address,
+        JSON.stringify(defaultTemplate),
         safe.address
       )
       .then((tx: any) => tx.wait());
@@ -172,8 +172,8 @@ describe("Module can be deployed and configured via the DeterministicDeploymentH
         masterCopy.address,
         initParams,
         saltNonce,
-        JSON.stringify(defaultTemplate),
         oracle.address,
+        JSON.stringify(defaultTemplate),
         safe.address
       )
       .then((tx: any) => tx.wait());


### PR DESCRIPTION
Deterministic Deployment Helper functions
Related to https://github.com/gnosis/zodiac-safe-app/issues/94.
This contract contains helper functions that can be used to deploy the RealityModule to a deterministic address even though the template ID is unknown at the deployment time.

* This is needed because if a new template is added in the same transaction and where the module is deployed, the template ID is unknown until the transaction executes.
* This is unnecessary if the template ID is already known (the template has been created in an earlier transaction).
* This functionality is helpful if the template will be created and the RealityModule deployed in the same transaction.

The contracts consist of multiple deployment and configuration functions that each have their pros and cons. The reason to provide multiple alternatives is that different circumstances will favor different versions.

---
**Usage of the `createTemplate` function  via delegatecall:**
In this scenario, we deploy the module as normal (just set the `templateId` to `0`). Then create a subsequent delegated call from the safe to `createTemplate` function. This will create a new template and set the new templateId in one transaction. Kind of like `createTemplateAndChangeOwner` but without the need to change the owner (the safe will already be the owner) and call via delegated call:
Pros: 
- The default `deployAndSetUpModule` function can be used (https://github.com/gnosis/zodiac/blob/dbe820aa8c9ee9d55e938b7fbdc1800dc89702db/src/factory/factory.ts#L7).

Cons:
- The init parameters (for the modules `setup` function) are required to be customized in the following way:
    - The templateId must be set to `0`.
---

**Usage of the `createTemplateAndChangeOwner` function directly:**
Pros: 
- The default `deployAndSetUpModule` function can be used (https://github.com/gnosis/zodiac/blob/dbe820aa8c9ee9d55e938b7fbdc1800dc89702db/src/factory/factory.ts#L7).

Cons:
- The init parameters (for the modules `setup` function) are required to be customized in the following way:
    - The owner of the module must be set to the address of the DeterministicDeploymentHelper contract. 
    - The templateId must be set to `0`.
- The `createTemplateAndChangeOwner` function must be called in the same transaction (for instance, via a multisend contract) as the deployment of the module. If not, somebody else could take over ownership of the module.
---

**Usage of the `deployWithEncodedParams` function  directly:**
Pros:
- The deployment of the module and `createTemplateAndChangeOwner` functionality are bundled together. There is no risk that the deployment and configuration do not happen in the same transaction.

Cons:
- The init parameters (for the modules `setup` function) are required to be customized in the following way:
    - The owner of the module must be set to the address of the DeterministicDeploymentHelper contract. 
    - The templateId must be set to `0`.
- The default `deployAndSetUpModule` function can NOT be used.
---

**Usage of the `deployWithTemplate` function  directly:**
Pros:
- The deployment of the module and `createTemplateAndChangeOwner` functionality are bundled together. There is no risk that the deployment and configuration do not happen in the same transaction.
- The input parameters are used as expected, there is no need to customize the deployment parameters in any special way.

Cons:
- The default `deployAndSetUpModule` function can NOT be used.


